### PR TITLE
Validate Text before replacing

### DIFF
--- a/src/textTools.js
+++ b/src/textTools.js
@@ -71,7 +71,7 @@ TextTools.prototype.buildInlines = function(textArray, styleContextStack) {
 * @return {Object}                   size of the specified string
 */
 TextTools.prototype.sizeOfString = function(text, styleContextStack) {
-	text = text.replace('\t', '    ');
+	text = text ? text.replace('\t', '    ') : '';
 
 	//TODO: refactor - extract from measure
 	var fontName = getStyleProperty({}, styleContextStack, 'font', 'Roboto');
@@ -94,7 +94,7 @@ TextTools.prototype.sizeOfString = function(text, styleContextStack) {
 
 function splitWords(text, noWrap) {
 	var results = [];
-	text = text.replace('\t', '    ');
+	text = text ? text.replace('\t', '    ') : '';
 
 	var array;
 	if (noWrap) {


### PR DESCRIPTION
The Text variable hasn’t been verified to have content. If it doesn’t PDFMake breaks and nothing is done. We are creating a conditional before trying to replace: if the variable hasn’t been defined or is undefined we proceed to place an empty String as to avoid further processing issues, if it is defined, then we proceed to replace the string as usual.
This caused entire PDFs to break its creation.
